### PR TITLE
fix: Remove field types in Dgraph types in schema.

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -45,14 +45,14 @@ const (
 
 	cDgraphSchema = `
 		type Tweet {
-			id_str: string
-			created_at: dateTime
-			message: string
-			urls: [string]
-			hashtags: [string]
-			author: User
-			mention: [User]
-			retweet: bool
+			id_str
+			created_at
+			message
+			urls
+			hashtags
+			author
+			mention
+			retweet
 		}
 		
 		type User {

--- a/js/index.js
+++ b/js/index.js
@@ -34,26 +34,26 @@ const dgraphClient = new dgraph.DgraphClient(dgraphClientStub);
 async function setSchema() {
   const schema = `
     type Tweet {
-      id_str: string
-      created_at: dateTime
-      message: string
-      urls: [string]
-      hashtags: [string]
-      author: User
-      mention: [User]
-      retweet: bool
+      id_str
+      created_at
+      message
+      urls
+      hashtags
+      author
+      mention
+      retweet
     }
 
     type User {
-      user_id: string
-      user_name: string
-      screen_name: string
-      description: string
-      friends_count: int
-      followers_count: int
-      verified: bool
-      profile_banner_url: string
-      profile_image_url: string
+      user_id
+      user_name
+      screen_name
+      description
+      friends_count
+      followers_count
+      verified
+      profile_banner_url
+      profile_image_url
     }
 
     user_id: string @index(exact) @upsert .


### PR DESCRIPTION
These field types are ignored.

In the newer versions of Dgraph, this shows a warning in the logs like the following:

    W0625 22:11:47.819350      15 parse.go:405] Type declaration for type Tweet includes deprecated information about field type for field id_str which will be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/flock/36)
<!-- Reviewable:end -->
