### PR TITLE
fix(go): Add query names in error logs and increase gRPC max message size.

### DIFF
--- a/go/client/main.go
+++ b/go/client/main.go
@@ -94,7 +94,7 @@ func (q *queryOne) getParams(dgr *dgo.Dgraph) error {
 	txn := dgr.NewReadOnlyTxn()
 	resp, err := txn.Query(context.Background(), query)
 	if err != nil {
-		log.Printf("error in quering dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -146,7 +146,7 @@ query all($tagVal: string) {
 	resp, err := txn.QueryWithVars(context.Background(), query,
 		map[string]string{"$tagVal": hashtag})
 	if err != nil {
-		log.Printf("error in quering dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -205,7 +205,7 @@ func (q *queryTwo) getParams(dgr *dgo.Dgraph) error {
 	txn := dgr.NewReadOnlyTxn()
 	resp, err := txn.Query(context.Background(), query)
 	if err != nil {
-		log.Printf("error in querying dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -258,7 +258,7 @@ query all($screenName: string) {
 	resp, err := txn.QueryWithVars(context.Background(), query,
 		map[string]string{"$screenName": screenName})
 	if err != nil {
-		log.Printf("error in querying dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -325,7 +325,7 @@ func (q *queryThree) runQuery(dgr *dgo.Dgraph) error {
 	txn := dgr.NewReadOnlyTxn()
 	resp, err := txn.Query(context.Background(), query)
 	if err != nil {
-		log.Printf("error in querying dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -389,7 +389,7 @@ func (q *queryFour) runQuery(dgr *dgo.Dgraph) error {
 	txn := dgr.NewReadOnlyTxn()
 	resp, err := txn.Query(context.Background(), query)
 	if err != nil {
-		log.Printf("error in querying dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -438,7 +438,7 @@ func (q *queryFive) getParams(dgr *dgo.Dgraph) error {
 	txn := dgr.NewReadOnlyTxn()
 	resp, err := txn.Query(context.Background(), query)
 	if err != nil {
-		log.Printf("error in querying dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -491,7 +491,7 @@ query all($userID: string) {
 	resp, err := txn.QueryWithVars(context.Background(), query,
 		map[string]string{"$userID": userID})
 	if err != nil {
-		log.Printf("error in querying dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -545,7 +545,7 @@ func (q *querySix) getParams(dgr *dgo.Dgraph) error {
 	txn := dgr.NewReadOnlyTxn()
 	resp, err := txn.Query(context.Background(), query)
 	if err != nil {
-		log.Printf("error in quering dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -616,7 +616,7 @@ func (q *querySeven) getParams(dgr *dgo.Dgraph) error {
 	txn := dgr.NewReadOnlyTxn()
 	resp, err := txn.Query(context.Background(), query)
 	if err != nil {
-		log.Printf("error in querying dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -698,7 +698,7 @@ func (q *queryEight) runQuery(dgr *dgo.Dgraph) error {
 	txn := dgr.NewReadOnlyTxn()
 	resp, err := txn.Query(context.Background(), query)
 	if err != nil {
-		log.Printf("error in querying dgraph, query: %v :: %v", query, err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -767,7 +767,7 @@ func (q *queryNine) getParams(dgr *dgo.Dgraph) error {
 	txn := dgr.NewReadOnlyTxn()
 	resp, err := txn.Query(context.Background(), query)
 	if err != nil {
-		log.Printf("error in querying dgraph :: %v", err)
+		log.Printf("error in querying dgraph %T :: %v", q, err)
 		return err
 	}
 
@@ -875,7 +875,7 @@ func runQuery(alphas []api.DgraphClient, wg *sync.WaitGroup,
 
 		if err != nil {
 			atomic.AddUint32(&stats.Failures, 1)
-			log.Printf("error in running parameter query :: %v", err)
+			log.Printf("error in running parameter query %T :: %v", query, err)
 			continue
 		}
 

--- a/go/client/main.go
+++ b/go/client/main.go
@@ -914,10 +914,18 @@ func reportStats() {
 }
 
 func newAPIClients(sockAddr []string) ([]api.DgraphClient, error) {
+	const GrpcMaxSize = 10 << 20 // 10 MB
+
 	var clients []api.DgraphClient
 
 	for _, sa := range sockAddr {
-		conn, err := grpc.Dial(sa, grpc.WithInsecure())
+		callOpts := append([]grpc.CallOption{},
+			grpc.MaxCallRecvMsgSize(GrpcMaxSize),
+			grpc.MaxCallSendMsgSize(GrpcMaxSize))
+		dialOpts := append([]grpc.DialOption{},
+			grpc.WithDefaultCallOptions(callOpts...),
+			grpc.WithInsecure())
+		conn, err := grpc.Dial(sa, dialOpts...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The error messages don't say what query ran that caused this error. This change prints the type name as the query name. e.g., `error in querying dgraph *main.queryOne`. 

Some queries return an error saying that the response exceeds the max message size of 4 MB. This change sets the max message size to 10 MB.



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/flock/37)
<!-- Reviewable:end -->
