### PR TITLE
log limits on go docker client

### DIFF
--- a/go/client/docker-compose.yml
+++ b/go/client/docker-compose.yml
@@ -8,3 +8,7 @@ services:
     labels:
       cluster: flock-cluster
     command: ["-a", "localhost:9080"]
+    logging:
+      options:
+        max-size: "100m"
+        max-file: "10"


### PR DESCRIPTION
If you use the docker-compose.yml for the go client, it will quickly overload the disk space on the server.  This will limit the size of the logs and rotate them out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/flock/39)
<!-- Reviewable:end -->
